### PR TITLE
Test/news bots coins endpoint

### DIFF
--- a/test_data/delete_news_bot.json
+++ b/test_data/delete_news_bot.json
@@ -1,0 +1,13 @@
+{
+    "Test [xxx]: DELETE News Bot Schema Validation" : {
+        "payload": {
+            "name": "coinTest",
+            "alias": "CT",
+            "symbol": "ct",
+            "category_id": 1,
+            "run_frequency": 20
+        },
+        "status_code": 200,
+        "expected_response": "{\"error\": None, \"success\": True}"
+    }
+}

--- a/test_data/post_chart.json
+++ b/test_data/post_chart.json
@@ -1,0 +1,259 @@
+{
+    "Test [xxx]: POST Chart Schema Validation" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "support_4": 30000, 
+            "temporality": "1d"
+        },
+        "status_code": 201
+    },
+    "Test [xxx]: POST Chart Required Fields Missing" : {
+        "payload": {},
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: coin_id, pair, temporality, coin_name, support_1, support_2, support_3, support_4, resistance_1, resistance_2, resistance_3, resistance_4, is_essential\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: temporality" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500,
+            "support_4": 30000
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: temporality\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: support_4" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: support_4\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: support_3" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: support_3\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: support_2" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_3": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: support_2\",\"message\": None, \"status\":400}"
+    },    
+    "Test [xxx]: POST Chart Required Field Missing: support_1" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_2": 34500, 
+            "support_3": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: support_1\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: resistance_4" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "support_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: resistance_4\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: resistance_3" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "support_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: resistance_3\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: resistance_2" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "resistance_1": 37000, 
+            "support_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_3": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: resistance_2\",\"message\": None, \"status\":400}"
+    },    
+    "Test [xxx]: POST Chart Required Field Missing: resistance_1" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "pair": "usdt", 
+            "support_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_2": 34500, 
+            "support_3": 33000, 
+            "support_4": 31500, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: resistance_1\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: pair" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "is_essential": false, 
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "support_4": 30000, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: pair\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: is_essential" : {
+        "payload": { 
+            "coin_id": 1, 
+            "coin_name": "btc", 
+            "pair": "usdt",
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "support_4": 30000, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: is_essential\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: coin_name" : {
+        "payload": { 
+            "coin_id": 1, 
+            "is_essential": false,  
+            "pair": "usdt",
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "support_4": 30000, 
+            "temporality": "1d"
+        },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: coin_name\",\"message\": None, \"status\":400}"
+    },
+    "Test [xxx]: POST Chart Required Field Missing: coin_id" : {
+        "payload": {  
+            "coin_name": "btc", 
+            "is_essential": false,  
+            "pair": "usdt",
+            "resistance_1": 37000, 
+            "resistance_2": 37500, 
+            "resistance_3": 39000, 
+            "resistance_4": 41000, 
+            "support_1": 34500, 
+            "support_2": 33000, 
+            "support_3": 31500, 
+            "support_4": 30000, 
+            "temporality": "1d"
+    },
+        "status_code": 400,
+        "expected_response": "{\"data\": None,\"error\": \"One or more required fields are missing: coin_id\",\"message\": None, \"status\":400}"
+    }
+}

--- a/test_data/post_news_bot.json
+++ b/test_data/post_news_bot.json
@@ -1,0 +1,52 @@
+{
+    "Test [xxx]: POST News Bots Schema Validation" : {
+        "payload": { 
+            "alias": "tc", 
+            "background_color": "#4287f5", 
+            "blacklist": "spam, scam, adult content", 
+            "category_id": 1, 
+            "dalle_prompt": "Dalle Pompt to test", 
+            "name": "testcoin", 
+            "run_frequency": 20, 
+            "url": "https://rss.news.google.com/search?q=tech%20news", 
+            "whitelist": "AI, machine learning, robotics"
+        },
+        "status_code": 201
+    },
+    "Test [xxx]: POST News Bots Required Fields Missing" : {
+        "payload": {},
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: name\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Name" : {
+        "payload": {
+            "alias": "CT"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: name\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Alias" : {
+        "payload": {
+            "name": "catTest"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: alias\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Category ID" : {
+        "payload": {
+            "name": "catTest",
+            "alias": "CT"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: category_id\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Run Frequency" : {
+        "payload": {
+            "name": "catTest",
+            "alias": "CT",
+            "category_id": 1
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: run_frequency\"}"
+    }
+}

--- a/test_data/post_news_bot_category.json
+++ b/test_data/post_news_bot_category.json
@@ -1,0 +1,29 @@
+{
+    "Test [xxx]: POST News Bots Category Schema Validation" : {
+        "payload": {
+            "alias": "CATTEST1",
+            "name": "CATTEST1",
+            "slack_channel": "slack channel test"
+        },
+        "status_code": 201
+    },
+    "Test [xxx]: POST News Bots Category Required Fields Missing" : {
+        "payload": {},
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Name and alias are required\"}"
+    },
+    "Test [xxx]: POST News Bots Category Required Field Missing: Name" : {
+        "payload": {
+            "alias": "CT"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Name and alias are required\"}"
+    },
+    "Test [xxx]: POST News Bots Category Required Field Missing: Alias" : {
+        "payload": {
+            "name": "catTest"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Name and alias are required\"}"
+    }
+}

--- a/test_data/put_news_bot.json
+++ b/test_data/put_news_bot.json
@@ -1,0 +1,14 @@
+{
+    "Test [xxx]: PUT News Bot Schema Validation" : {
+        "payload": {
+            "name": "coinTest1",
+            "alias": "CT1",
+            "category_id": 2,
+            "background_color": "#4287f5",
+            "dalle_prompt": "Update Dalle Prompt to test", 
+            "run_frequency": 25,
+            "prompt":  "Update Prompt to test"
+        },
+        "status_code": 200
+    }
+}

--- a/test_data/put_news_bot_category.json
+++ b/test_data/put_news_bot_category.json
@@ -1,0 +1,10 @@
+{
+    "Test [xxx]: PUT News Bot Category Schema Validation" : {
+        "payload": {
+            "name": "catTest1",
+            "alias": "CT1",
+            "border_color": "#FC5404"
+        },
+        "status_code": 200
+    }
+}

--- a/test_data/schemas.py
+++ b/test_data/schemas.py
@@ -353,3 +353,232 @@ NEWS_BOTS_CATEGORY_SCHEMA = {
     },
     "required": ["error", "success"]
 }
+
+NEWS_BOTS_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "alias": { "type": ["null", "string"] },
+          "background_color": { "type": ["null", "string"] },
+          "category_id": { "type": "integer" },
+          "created_at": { "type": ["null", "string"], "format": "date-time" },
+          "dalle_prompt": { "type": ["null", "string"] },
+          "icon": { "type": ["null", "string"] },
+          "id": { "type": "integer" },
+          "is_active": { "type": "boolean" },
+          "name": { "type": "string" },
+          "prompt": { "type": ["null", "string"] },
+          "run_frequency": { "type": "string" },
+          "updated_at": { "type": ["null", "string"], "format": "date-time" }
+        },
+        "required": [
+          "alias",
+          "background_color",
+          "category_id",
+          "created_at",
+          "dalle_prompt",
+          "icon",
+          "id",
+          "is_active",
+          "name",
+          "prompt",
+          "run_frequency",
+          "updated_at"
+        ]
+      }
+    },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "success"]
+}
+
+POST_NEWS_BOT_RESPONSE = {
+  "type": "object",
+  "properties": {
+    "bot": {
+      "type": "object",
+      "properties": {
+        "alias": { "type": "string" },
+        "background_color": { "type": "string", "format": "color" },
+        "category_id": { "type": "integer" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "dalle_prompt": { "type": "string" },
+        "icon": { "type": "string", "format": "uri" },
+        "id": { "type": "integer" },
+        "is_active": { "type": "boolean" },
+        "last_run_status": { "type": ["string", "null"] },
+        "last_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "name": { "type": "string" },
+        "next_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "prompt": { "type": "string" },
+        "run_count": { "type": "integer" },
+        "run_frequency": { "type": "integer" },
+        "status": { "type": "string" },
+        "updated_at": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "alias",
+        "background_color",
+        "category_id",
+        "created_at",
+        "dalle_prompt",
+        "icon",
+        "id",
+        "is_active",
+        "name",
+        "run_count",
+        "run_frequency",
+        "status",
+        "updated_at"
+      ]
+    },
+    "data": { "type": ["object", "null"] },
+    "error": { "type": ["object", "null", "string"] },
+    "message": { "type": "string" },
+    "success": { "type": "boolean" }
+  }
+}
+
+NEWS_BOT_METRICS_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "articles_processed": { "type": "integer" },
+              "articles_saved": { "type": "integer" },
+              "bot_id": { "type": "integer" },
+              "cpu_percent": { "type": "number" },
+              "end_time": { "type": ["string", "null"], "format": "date-time" },
+              "error_reasons": { "type": ["string", "null"] },
+              "filter_reasons": { "type": ["string", "null"] },
+              "id": { "type": "integer" },
+              "memory_percent": { "type": "number" },
+              "start_time": { "type": ["string", "null"], "format": "date-time" },
+              "total_articles_found": { "type": "integer" },
+              "total_errors": { "type": "integer" },
+              "total_filtered": { "type": "integer" },
+              "total_runtime": { "type": ["string", "null"] }
+            },
+            "required": [
+              "articles_processed",
+              "articles_saved",
+              "bot_id",
+              "cpu_percent",
+              "end_time",
+              "error_reasons",
+              "filter_reasons",
+              "id",
+              "memory_percent",
+              "start_time",
+              "total_articles_found",
+              "total_errors",
+              "total_filtered",
+              "total_runtime"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "current_page": { "type": "integer" },
+            "has_next": { "type": "boolean" },
+            "has_prev": { "type": "boolean" },
+            "per_page": { "type": "integer" },
+            "total_items": { "type": "integer" },
+            "total_pages": { "type": "integer" }
+          },
+          "required": [
+            "current_page",
+            "has_next",
+            "has_prev",
+            "per_page",
+            "total_items",
+            "total_pages"
+          ]
+        }
+      },
+      "required": ["metrics", "pagination"]
+    },
+    "error": { "type": ["string", "null"] },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "error", "success"]
+}
+
+NEWS_BOT_RESPONSE_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "alias": { "type": "string" },
+        "background_color": { "type": "string" },
+        "blacklist": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "category_id": { "type": "integer" },
+        "created_at": { "type": ["string", "null"], "format": "date-time" },
+        "dalle_prompt": { "type": "string" },
+        "icon": { "type": "string", "format": "uri" },
+        "id": { "type": "integer" },
+        "is_active": { "type": "boolean" },
+        "keywords": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "last_run_status": { "type": ["string", "null"] },
+        "last_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "name": { "type": "string" },
+        "next_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "prompt": { "type": "string" },
+        "run_count": { "type": ["integer", "null"] },
+        "run_frequency": { "type": "string" },
+        "site": {
+          "type": "object",
+          "properties": {
+            "bot_id": { "type": "integer" },
+            "created_at": { "type": ["string", "null"], "format": "date-time" },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "updated_at": { "type": ["string", "null"], "format": "date-time" },
+            "url": { "type": "string", "format": "uri" }
+          },
+          "required": ["bot_id", "id", "name", "url"]
+        },
+        "status": { "type": ["string", "null"] },
+        "updated_at": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "alias",
+        "background_color",
+        "blacklist",
+        "category_id",
+        "dalle_prompt",
+        "icon",
+        "id",
+        "is_active",
+        "keywords",
+        "name",
+        "prompt",
+        "run_frequency",
+        "site",
+        "status",
+        "updated_at"
+      ]
+    },
+    "error": { "type": ["string", "null"] },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "error", "success"]
+}

--- a/test_data/schemas.py
+++ b/test_data/schemas.py
@@ -245,3 +245,111 @@ OHLC_CHART_SCHEMA = {
   },
   "required": ["data", "error"]
 }
+
+BOTS_SCHEMA = {
+    "type": "object",
+    "properties": {
+    "alias": { "type": ["string", "null"] },
+    "background_color": { "type": ["string", "null"] },
+    "category_id": { "type": "integer" },
+    "created_at": { "type": ["string", "null"], "format": "date-time" },
+    "dalle_prompt": { "type": ["string", "null"] },
+    "icon": { "type": ["string", "null"], "format": "uri" },
+    "id": { "type": "integer" },
+    "is_active": { "type": "boolean" },
+    "last_run_status": { "type": ["string", "null"] },
+    "last_run_time": { "type": ["string", "null"], "format": "date-time" },
+    "name": { "type": "string" },
+    "next_run_time": { "type": ["string", "null"], "format": "date-time" },
+    "prompt": { "type": ["string", "null"] },
+    "run_count": { "type": ["integer", "null"] },
+    "run_frequency": { "type": "string" },
+    "status": { "type": ["string", "null"] },
+    "updated_at": { "type":  ["null", "string"], "format": "date-time" }
+    },
+    "required": [
+    "alias",
+    "background_color",
+    "category_id",
+    "created_at",
+    "dalle_prompt",
+    "icon",
+    "id",
+    "is_active",
+    "last_run_status",
+    "last_run_time",
+    "name",
+    "next_run_time",
+    "prompt",
+    "run_count",
+    "run_frequency",
+    "status",
+    "updated_at"
+    ]
+}
+
+NEWS_BOTS_CATEGORY_SCHEMA = {
+    "type": "object",
+    "properties": {
+    "alias": { "type": "string" },
+    "border_color": { "type": "string" },
+    "bots": {
+        "type": "array",
+        "items": BOTS_SCHEMA
+    },
+    "created_at": { "type": "string", "format": "date-time" },
+    "icon": { "type": "string" },
+    "id": { "type": "integer" },
+    "is_active": { "type": "boolean" },
+    "name": { "type": "string" },
+    "slack_channel": { "type": "string" },
+    "updated_at": { "type":  ["null", "string"], "format": "date-time" }
+    },
+    "required": [
+        "alias",
+        "name"
+    ]
+}
+
+NEWS_BOT_CATEGORY_RESPONSE_SCHEMA = { 
+    "type": "object",
+    "properties": {
+        "data": NEWS_BOTS_CATEGORY_SCHEMA,
+        "error": { "type": ["null", "string"] },
+        "success": { "type": "boolean" }
+    }
+ }
+
+NEWS_BOTS_CATEGORIES_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "data": {
+        "type": "object",
+        "properties": {
+            "categories": {
+            "type": "array",
+            "items": NEWS_BOTS_CATEGORY_SCHEMA,
+            },
+        },
+        "required": ["categories"]
+        },
+        "error": { "type": ["null", "string"] },
+        "success": { "type": "boolean" }
+    },
+    "required": ["error", "success"]
+}
+
+NEWS_BOTS_CATEGORY_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "data": {
+        "type": "object",
+        "properties": {
+            "category": NEWS_BOTS_CATEGORY_SCHEMA
+            }
+        },
+        "error": { "type": ["null", "string"] },
+        "success": { "type": "boolean" }
+    },
+    "required": ["error", "success"]
+}

--- a/test_data/schemas.py
+++ b/test_data/schemas.py
@@ -80,3 +80,168 @@ CATEGORY_RESPONSE_SCHEMA = {
     },
     "required": ["category", "error", "success"] 
 }
+
+CHART_SCHEMA = {
+    "type": ["object", "null"],
+    "properties": {
+        "chart_id": {"type": "integer"},
+        "coin_bot_id": {"type": "integer"},
+        "created_at": {"type": "string", "format": "date-time"},
+        "is_essential": {"type": "boolean"},
+        "pair": {"type": "string"},
+        "resistance_1": {"type": "number"},
+        "resistance_2": {"type": "number"},
+        "resistance_3": {"type": "number"},
+        "resistance_4": {"type": "number"},
+        "support_1": {"type": "number"},
+        "support_2": {"type": "number"},
+        "support_3": {"type": "number"},
+        "support_4": {"type": "number"},
+        "temporality": {"type": "string"},
+        "token": {"type": "string"},
+        "updated_at": {"type": "string", "format": "date-time"}
+    },
+    "required": [
+        "chart_id",
+        "coin_bot_id",
+        "created_at",
+        "is_essential",
+        "pair",
+        "resistance_1",
+        "resistance_2",
+        "resistance_3",
+        "resistance_4",
+        "support_1",
+        "support_2",
+        "support_3",
+        "support_4",
+        "temporality",
+        "token",
+        "updated_at"
+    ]
+}
+
+DATA_ITEM_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "close": {"type": "number"},
+        "date": {"type": "string", "format": "date-time"},
+        "high": {"type": "number"},
+        "low": {"type": "number"},
+        "open": {"type": "number"}
+    },
+    "required": ["close", "date", "high", "low", "open"]
+}
+
+DATA_ARRAY_SCHEMA = {
+    "type": "array",
+    "items": DATA_ITEM_SCHEMA
+}
+
+CHART_RESPONSE_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "data": {"anyOf": [CHART_SCHEMA, DATA_ARRAY_SCHEMA]},
+        "error": {"type": ["string", "null"]},
+        "message": {"type": ["string", "null"]},
+        "status": {"type": "integer"}
+    },
+    "required": ["data", "error", "message", "status"]
+}
+
+CHART_GET_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "error": {
+      "type": ["null", "string"]
+    },
+    "message": CHART_SCHEMA,
+    "status": {
+      "type": "integer"
+    }
+  },
+  "required": ["error", "message", "status"]
+}
+
+TOP_MOVERS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "data": {
+        "type": "object",
+        "properties": {
+            "top_10_gainers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                "current_price": { "type": "number" },
+                "id": { "type": "string" },
+                "image": { "type": "string", "format": "uri" },
+                "last_updated": { "type": "string", "format": "date-time" },
+                "name": { "type": "string" },
+                "price_change_percentage_24h": { "type": "number" },
+                "symbol": { "type": "string" }
+                },
+                "required": [
+                "current_price",
+                "id",
+                "image",
+                "last_updated",
+                "name",
+                "price_change_percentage_24h",
+                "symbol"
+                ]
+            }
+            },
+            "top_10_losers": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                "current_price": { "type": "number" },
+                "id": { "type": "string" },
+                "image": { "type": "string", "format": "uri" },
+                "last_updated": { "type": "string", "format": "date-time" },
+                "name": { "type": "string" },
+                "price_change_percentage_24h": { "type": "number" },
+                "symbol": { "type": "string" }
+                },
+                "required": [
+                "current_price",
+                "id",
+                "image",
+                "last_updated",
+                "name",
+                "price_change_percentage_24h",
+                "symbol"
+                ]
+            }
+            }
+        },
+        "required": ["top_10_gainers", "top_10_losers"]
+        },
+        "order": { "type": "string" },
+        "success": { "type": "boolean" }
+    },
+    "required": ["data", "order", "success"]
+}
+
+OHLC_DATA_ITEMS_SCHEMA = {
+    "type": "array",
+    "minItems": 5,
+    "maxItems": 5
+}
+
+OHLC_CHART_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": OHLC_DATA_ITEMS_SCHEMA
+    },
+    "error": {
+      "type": ["string", "null"]
+    }
+  },
+  "required": ["data", "error"]
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,42 @@
+import os
+from dotenv import load_dotenv
+import pytest
+from utils.api_client import APIClient
+
+# Load environment variables
+load_dotenv()
+
+@pytest.fixture(scope="module")
+def api_client(request) -> APIClient:
+    """
+    Provides a configured APIClient instance for use in tests, with parameters passed to it.
+
+    Args:
+        request: Pytest request fixture used to access parameters passed during the test call.
+
+    Returns:
+        APIClient: Configured API client with base URL and headers.
+    """
+
+    # Default values for headers
+    default_accept = "multipart/form-data"
+    default_content_type = None
+
+    # Fetch the parameters if provided in the test, otherwise use defaults
+    accept = request.param.get("accept", default_accept) if hasattr(request, 'param') else default_accept
+    content_type = request.param.get("content_type", default_content_type) if hasattr(request, 'param') else default_content_type
+
+    base_url = os.getenv("AI_ALPHA_URL")
+    api_key = os.getenv("API_KEY")
+    
+    if not base_url or not api_key:
+        raise ValueError("Environment variables 'AI_ALPHA_URL' or 'API_KEY' are missing.")
+    
+    headers = {
+        'accept': accept,
+        'X-API-Key': api_key
+    }
+    if content_type:  # Only include 'Content-Type' if it is provided
+        headers['Content-Type'] = content_type
+    
+    return APIClient(base_url, headers)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,26 +11,42 @@ def api_client(request) -> APIClient:
     """
     Provides a configured APIClient instance for use in tests, with parameters passed to it.
 
+    This fixture supports customization of the API client configuration by allowing test cases 
+    to provide the following parameters via `request.param`:
+    
+    - `base_url` (str): The base URL for the API. Defaults to the `AI_ALPHA_URL` environment variable.
+    - `accept` (str): The value for the `accept` header. Defaults to "multipart/form-data".
+    - `content_type` (str): The value for the `Content-Type` header. Defaults to None (header not included).
+
+    Environment variables:
+    - `AI_ALPHA_URL`: Used as the default value for `base_url` if not provided via `request.param`.
+    - `API_KEY`: Required for the `X-API-Key` header.
+
     Args:
         request: Pytest request fixture used to access parameters passed during the test call.
 
     Returns:
-        APIClient: Configured API client with base URL and headers.
-    """
+        APIClient: Configured API client with the specified base URL and headers.
 
+    Raises:
+        ValueError: If the `AI_ALPHA_URL` or `API_KEY` environment variable is missing, or if `base_url`
+                    is not provided via parameters or environment variable.
+    """
     # Default values for headers
     default_accept = "multipart/form-data"
     default_content_type = None
 
     # Fetch the parameters if provided in the test, otherwise use defaults
+    base_url = request.param.get("base_url", os.getenv("AI_ALPHA_URL")) if hasattr(request, 'param') else os.getenv("AI_ALPHA_URL")
     accept = request.param.get("accept", default_accept) if hasattr(request, 'param') else default_accept
     content_type = request.param.get("content_type", default_content_type) if hasattr(request, 'param') else default_content_type
-
-    base_url = os.getenv("AI_ALPHA_URL")
-    api_key = os.getenv("API_KEY")
     
-    if not base_url or not api_key:
-        raise ValueError("Environment variables 'AI_ALPHA_URL' or 'API_KEY' are missing.")
+    if not base_url:
+        raise ValueError("Base URL is required. Provide 'base_url' as a parameter or set the 'AI_ALPHA_URL' environment variable.")
+
+    api_key = os.getenv("API_KEY")
+    if not api_key:
+        raise ValueError("Environment variable 'API_KEY' is missing.")
     
     headers = {
         'accept': accept,

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -7,19 +7,6 @@ from test_data.schemas import CATEGORIES_RESPONSE_SCHEMA, CATEGORY_RESPONSE_SCHE
 
 load_dotenv()
 
-@pytest.fixture(scope="module")
-def api_client() -> APIClient:
-    """
-    Creates and returns an instance of the APIClient with the base URL and API key.
-
-    Returns:
-        APIClient: An instance of APIClient configured with base URL and headers.
-    """
-    return APIClient(os.getenv("AI_ALPHA_URL"), {
-            'accept': 'multipart/form-data',
-            'X-API-Key': os.getenv("API_KEY")
-            })
-
 def test_get_categories(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving all categories.

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -1,11 +1,8 @@
 import pytest, os
-from dotenv import load_dotenv
 from utils.api_client import APIClient
 from utils.assertions import Assertions
 from utils.handlers import Handlers
 from test_data.schemas import CATEGORIES_RESPONSE_SCHEMA, CATEGORY_RESPONSE_SCHEMA
-
-load_dotenv()
 
 def test_get_categories(api_client: APIClient) -> None:
     """

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -15,7 +15,7 @@ def api_client() -> APIClient:
     Returns:
         APIClient: An instance of APIClient configured with base URL and headers.
     """
-    return APIClient(os.getenv("BASE_URL"), {
+    return APIClient(os.getenv("AI_ALPHA_URL"), {
             'accept': 'multipart/form-data',
             'X-API-Key': os.getenv("API_KEY")
             })

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -1,0 +1,107 @@
+import pytest, os, json
+from dotenv import load_dotenv
+from utils.api_client import APIClient
+from utils.assertions import Assertions
+from utils.handlers import Handlers
+from test_data.schemas import CHART_RESPONSE_SCHEMA, TOP_MOVERS_SCHEMA, OHLC_CHART_SCHEMA, CHART_GET_SCHEMA
+
+load_dotenv()
+
+@pytest.fixture(scope="module")
+def api_client() -> APIClient:
+    """
+    Creates and returns an instance of the APIClient with the base URL and API key for use in tests.
+
+    Returns:
+        APIClient: An instance of APIClient configured with base URL and headers.
+    """
+    
+    return APIClient(os.getenv("AI_ALPHA_URL"), {
+            'accept': 'application/json',
+            'Content-Type': 'application/json',
+            'X-API-Key': os.getenv("API_KEY")
+            })
+
+
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_chart.json")))
+def test_post_chart(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the POST endpoint for creating a new chart.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or schema.
+    """
+    response = api_client.post("chart", json.dumps(test_data['payload']))
+    response_data = response.json()
+    Assertions.assert_status_code(response, test_data['status_code'])
+    response_data = response.json()
+    Assertions.validate_schema(response_data, CHART_RESPONSE_SCHEMA)
+    if 'expected_response' in test_data:
+        Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
+    api_client.delete(f"chart/{response_data['data']['chart_id']}") if test_data['status_code'] == 201 else None
+
+
+def test_get_chart(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving a specific chart by ID.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.get(f"chart?coin_name=&coin_id=1&temporality=1d&pair=usdt")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, CHART_GET_SCHEMA)
+
+def test_get_total3_chart(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving a total3 chart by days.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or schema.
+    """
+    response = api_client.get("chart/total3?days=1")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, CHART_RESPONSE_SCHEMA)
+
+def test_get_top_movers(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving a top movers.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or schema.
+    """
+    response = api_client.get("chart/top-movers")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, TOP_MOVERS_SCHEMA)
+
+def test_get_ohlc_chart(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving a OHLC Chart.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or schema.
+    """
+    response = api_client.get("chart/ohlc?gecko_id=1&vs_currency=usd&interval=1d&precision=2&symbol=BTC")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, OHLC_CHART_SCHEMA)

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -1,11 +1,9 @@
 import pytest, os, json
-from dotenv import load_dotenv
 from utils.api_client import APIClient
 from utils.assertions import Assertions
 from utils.handlers import Handlers
 from test_data.schemas import CHART_RESPONSE_SCHEMA, TOP_MOVERS_SCHEMA, OHLC_CHART_SCHEMA, CHART_GET_SCHEMA
 
-load_dotenv()
 
 @pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_chart.json")))

--- a/tests/test_chart.py
+++ b/tests/test_chart.py
@@ -7,45 +7,38 @@ from test_data.schemas import CHART_RESPONSE_SCHEMA, TOP_MOVERS_SCHEMA, OHLC_CHA
 
 load_dotenv()
 
-@pytest.fixture(scope="module")
-def api_client() -> APIClient:
-    """
-    Creates and returns an instance of the APIClient with the base URL and API key for use in tests.
-
-    Returns:
-        APIClient: An instance of APIClient configured with base URL and headers.
-    """
-    
-    return APIClient(os.getenv("AI_ALPHA_URL"), {
-            'accept': 'application/json',
-            'Content-Type': 'application/json',
-            'X-API-Key': os.getenv("API_KEY")
-            })
-
-
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_chart.json")))
-def test_post_chart(api_client: APIClient, test_name: str, test_data: dict) -> None:
+def test_post_chart(api_client, test_name: str, test_data: dict) -> None:
     """
     Tests the POST endpoint for creating a new chart.
 
     Args:
         api_client (APIClient): The API client used for making requests.
         test_name (str): The name of the test case.
-        test_data (dict): The payload and expected status code for the request.
+        test_data (dict): A dictionary containing the payload and expected status code for the POST request.
 
     Raises:
         AssertionError: If the response does not meet the expected status code or schema.
     """
     response = api_client.post("chart", json.dumps(test_data['payload']))
     response_data = response.json()
+    
+    # Assert the status code matches the expected value
     Assertions.assert_status_code(response, test_data['status_code'])
     response_data = response.json()
+
+    # Validate the response schema
     Assertions.validate_schema(response_data, CHART_RESPONSE_SCHEMA)
+    
+    # If an 'expected_response' is provided, assert that the response contains the expected content
     if 'expected_response' in test_data:
         Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
+
+    # Clean up: Delete the created chart if the status code indicates successful creation
     api_client.delete(f"chart/{response_data['data']['chart_id']}") if test_data['status_code'] == 201 else None
 
-
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 def test_get_chart(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving a specific chart by ID.
@@ -57,10 +50,15 @@ def test_get_chart(api_client: APIClient) -> None:
         AssertionError: If the response does not meet the expected conditions.
     """
     response = api_client.get(f"chart?coin_name=&coin_id=1&temporality=1d&pair=usdt")
+    
+    # Assert the status code matches the expected value
     Assertions.assert_status_code(response, 200)
     response_data = response.json()
+
+    # Validate the response schema
     Assertions.validate_schema(response_data, CHART_GET_SCHEMA)
 
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 def test_get_total3_chart(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving a total3 chart by days.
@@ -72,10 +70,15 @@ def test_get_total3_chart(api_client: APIClient) -> None:
         AssertionError: If the response does not meet the expected status code or schema.
     """
     response = api_client.get("chart/total3?days=1")
+    
+    # Assert the status code matches the expected value
     Assertions.assert_status_code(response, 200)
     response_data = response.json()
+
+    # Validate the response schema
     Assertions.validate_schema(response_data, CHART_RESPONSE_SCHEMA)
 
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 def test_get_top_movers(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving a top movers.
@@ -87,10 +90,15 @@ def test_get_top_movers(api_client: APIClient) -> None:
         AssertionError: If the response does not meet the expected status code or schema.
     """
     response = api_client.get("chart/top-movers")
+    
+    # Assert the status code matches the expected value
     Assertions.assert_status_code(response, 200)
     response_data = response.json()
+    
+    # Validate the response schema
     Assertions.validate_schema(response_data, TOP_MOVERS_SCHEMA)
 
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
 def test_get_ohlc_chart(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving a OHLC Chart.
@@ -102,6 +110,10 @@ def test_get_ohlc_chart(api_client: APIClient) -> None:
         AssertionError: If the response does not meet the expected status code or schema.
     """
     response = api_client.get("chart/ohlc?gecko_id=1&vs_currency=usd&interval=1d&precision=2&symbol=BTC")
+    
+    # Assert the status code matches the expected value
     Assertions.assert_status_code(response, 200)
     response_data = response.json()
+    
+    # Validate the response schema
     Assertions.validate_schema(response_data, OHLC_CHART_SCHEMA)

--- a/tests/test_coin.py
+++ b/tests/test_coin.py
@@ -1,11 +1,8 @@
 import pytest, os
-from dotenv import load_dotenv
 from utils.api_client import APIClient
 from utils.assertions import Assertions
 from utils.handlers import Handlers
 from test_data.schemas import *
-
-load_dotenv()
 
 def test_get_coins(api_client: APIClient) -> None:
     """

--- a/tests/test_coin.py
+++ b/tests/test_coin.py
@@ -7,19 +7,6 @@ from test_data.schemas import *
 
 load_dotenv()
 
-@pytest.fixture(scope="module")
-def api_client() -> APIClient:
-    """
-    Creates and returns an instance of the APIClient with the base URL and API key.
-
-    Returns:
-        APIClient: An instance of APIClient configured with base URL and headers.
-    """
-    return APIClient(os.getenv("AI_ALPHA_URL"), {
-            'accept': 'multipart/form-data',
-            'X-API-Key': os.getenv("API_KEY")
-            })
-
 def test_get_coins(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving all coins.

--- a/tests/test_coin.py
+++ b/tests/test_coin.py
@@ -15,7 +15,7 @@ def api_client() -> APIClient:
     Returns:
         APIClient: An instance of APIClient configured with base URL and headers.
     """
-    return APIClient(os.getenv("BASE_URL"), {
+    return APIClient(os.getenv("AI_ALPHA_URL"), {
             'accept': 'multipart/form-data',
             'X-API-Key': os.getenv("API_KEY")
             })

--- a/tests/test_news_bots.py
+++ b/tests/test_news_bots.py
@@ -1,0 +1,148 @@
+import pytest, os, json
+from dotenv import load_dotenv
+from utils.api_client import APIClient
+from utils.assertions import Assertions
+from utils.handlers import Handlers
+from test_data.schemas import NEWS_BOTS_SCHEMA, POST_NEWS_BOT_RESPONSE, NEWS_BOT_METRICS_SCHEMA, NEWS_BOT_RESPONSE_SCHEMA
+
+load_dotenv()
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_bots(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving all news bots data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bots")
+    Assertions.assert_status_code(response, 200)
+    Assertions.validate_schema(response.json(), NEWS_BOTS_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_news_bot.json")))
+def test_post_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the POST endpoint for creating a new news bot with associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code, expected response or JSON schema.
+    """
+    response = api_client.post("bot", json.dumps(test_data['payload']))
+    response_data = response.json()
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.validate_schema(response_data, POST_NEWS_BOT_RESPONSE)
+    if 'expected_response' in test_data:
+        Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
+    api_client.delete(f"bot/{response_data['bot']['id']}") if test_data['status_code'] == 201 else None
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_news_bot.json")))
+def test_delete_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the DELETE endpoint for deleting a news bot.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected response for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or response.
+    """
+    response = api_client.post("bot", json.dumps(test_data['payload']))
+    response_data = response.json()
+    response = api_client.delete(f"bot/{response_data['bot']['id']}")
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.assert_response_contains(response.json(), eval(test_data['expected_response']))
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_news_bot_metrics(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving metrics for a specific bot with pagination and date filtering options.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bot/33/metrics")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOT_METRICS_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_bot(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving information for a specific bot, including related keywords, blacklist items, and site data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bot?bot_id=33")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOT_RESPONSE_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_news_bot.json")))
+def test_put_news_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the PUT endpoint for updating an existing bot identified by its id. it allows for modification of various bot properties and associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.post("bot", json.dumps({'name': 'catTest','alias': 'CT', 'category_id': '1', 'run_frequency': 20}), [])
+    response_data = response.json()
+    response1 = api_client.put(f"bot/{response_data['bot']['id']}", json.dumps(test_data['payload'])) 
+    response_data1 = response1.json()
+    Assertions.assert_status_code(response1, test_data['status_code'])
+    test_data['payload']['icon'] = 'https://aialphaicons.s3.us-east-2.amazonaws.com/ct1.svg'
+    Assertions.assert_response_contains(response_data1['data'], test_data['payload'])
+    api_client.delete(f"bot/{response_data1['data']['id']}") if test_data['status_code'] == 200 else None
+
+    
+
+

--- a/tests/test_news_bots_category.py
+++ b/tests/test_news_bots_category.py
@@ -1,0 +1,106 @@
+import pytest, os, json
+from dotenv import load_dotenv
+from utils.api_client import APIClient
+from utils.assertions import Assertions
+from utils.handlers import Handlers
+from test_data.schemas import NEWS_BOTS_CATEGORIES_SCHEMA, NEWS_BOTS_CATEGORY_SCHEMA, NEWS_BOT_CATEGORY_RESPONSE_SCHEMA
+
+load_dotenv()
+
+def test_get_categories(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving all news bots categories.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.get("categories")
+    Assertions.assert_status_code(response, 200)
+    Assertions.validate_schema(response.json(), NEWS_BOTS_CATEGORIES_SCHEMA)
+
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_news_bot_category.json")))
+def test_post_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the POST endpoint for creating a new news bots category.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or schema.
+    """
+    response = api_client.post("category", json.dumps(test_data['payload']))
+    response_data = response.json()
+    Assertions.assert_status_code(response, test_data['status_code'])
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOT_CATEGORY_RESPONSE_SCHEMA)
+    if 'expected_response' in test_data:
+        Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
+    api_client.delete(f"category/{response_data['data']['id']}") if test_data['status_code'] == 201 else None
+
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_category.json")))
+def test_delete_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the DELETE endpoint for deleting a news bot category.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected response for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.post("category", json.dumps(test_data['payload']))
+    response_data = response.json()
+    response = api_client.delete(f"category/{response_data['data']['id']}")
+    Assertions.assert_status_code(response, test_data['status_code'])
+
+def test_get_category(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving a specific news bot category by ID.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.get("category?category_name=bitcoin")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOTS_CATEGORY_SCHEMA)
+
+@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "multipart/form-data"}], indirect=True)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_news_bot_category.json")))
+def test_put_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the PUT endpoint for updating a news bot category.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.post("category", json.dumps({'name': 'catTest','alias': 'CT'}), [])
+    response_data = response.json()
+    response1 = api_client.put(f"category/{response_data['data']['id']}", json.dumps(test_data['payload'])) 
+    response_data1 = response1.json()
+    Assertions.assert_status_code(response1, test_data['status_code'])
+    test_data['payload']['icon'] = 'https://aialphaicons.s3.us-east-2.amazonaws.com/ct1.svg'
+    Assertions.assert_response_contains(response_data1['data']['category'], test_data['payload'])
+    api_client.delete(f"category/{response_data1['data']['category']['id']}") if test_data['status_code'] == 200 else None
+
+    
+
+

--- a/tests/test_news_bots_category.py
+++ b/tests/test_news_bots_category.py
@@ -7,6 +7,11 @@ from test_data.schemas import NEWS_BOTS_CATEGORIES_SCHEMA, NEWS_BOTS_CATEGORY_SC
 
 load_dotenv()
 
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "accept": "application/json"}], 
+    indirect=True
+)
 def test_get_categories(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving all news bots categories.
@@ -21,7 +26,11 @@ def test_get_categories(api_client: APIClient) -> None:
     Assertions.assert_status_code(response, 200)
     Assertions.validate_schema(response.json(), NEWS_BOTS_CATEGORIES_SCHEMA)
 
-@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_news_bot_category.json")))
 def test_post_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """
@@ -44,7 +53,11 @@ def test_post_category(api_client: APIClient, test_name: str, test_data: dict) -
         Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
     api_client.delete(f"category/{response_data['data']['id']}") if test_data['status_code'] == 201 else None
 
-@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "application/json"}], indirect=True)
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_category.json")))
 def test_delete_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """
@@ -63,6 +76,11 @@ def test_delete_category(api_client: APIClient, test_name: str, test_data: dict)
     response = api_client.delete(f"category/{response_data['data']['id']}")
     Assertions.assert_status_code(response, test_data['status_code'])
 
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
 def test_get_category(api_client: APIClient) -> None:
     """
     Tests the GET endpoint for retrieving a specific news bot category by ID.
@@ -78,7 +96,11 @@ def test_get_category(api_client: APIClient) -> None:
     response_data = response.json()
     Assertions.validate_schema(response_data, NEWS_BOTS_CATEGORY_SCHEMA)
 
-@pytest.mark.parametrize("api_client",[{"content_type": "application/json", "accept": "multipart/form-data"}], indirect=True)
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_news_bot_category.json")))
 def test_put_category(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """


### PR DESCRIPTION
This pull request introduces a comprehensive test suite for the News Bot API endpoints. Below is a detailed breakdown of the additions:

Changes Introduced:

**GET Endpoints:**
Added tests for retrieving all bots (test_get_bots).
Added tests for retrieving metrics for a specific bot (test_get_news_bot_metrics).
Added tests for retrieving details of a specific bot by ID (test_get_bot).
**POST Endpoints:**
Added tests for creating a new bot with associated data (test_post_bot).
**PUT Endpoints:**
Added tests for updating an existing bot (test_put_news_bot).
**DELETE Endpoints:**
Added tests for deleting a bot (test_delete_bot).

**Key Features:**
_Parameterized Testing:_
Use of pytest.mark.parametrize for data-driven testing, improving coverage across multiple test cases.
_Schema Validation:_
Response validation against predefined schemas (NEWS_BOTS_SCHEMA, POST_NEWS_BOT_RESPONSE, etc.) using the Assertions.validate_schema method.
_Dynamic Test Data Handling:_
Utilization of Handlers.create_test_tuple for dynamically generating test cases from JSON files.
_Environment Variable Integration:_
Base URL and configurations are retrieved from environment variables using dotenv.
_Cleanup Logic:_
Automated cleanup of test-created entities (e.g., deleting a bot after a successful POST).
_Files Added/Modified:_
Test File: Added test_news_bots.py containing all test cases.
Schema Files: Updated test_data/schemas.py with additional schemas for response validation.
Test Data: Added JSON files (post_news_bot.json, put_news_bot.json, etc.) for parameterized tests.

How to Test:
Ensure all dependencies are installed (pytest, python-dotenv, etc.).
Configure the .env file with the required environment variables (NEWS_BOT_URL).
Run the test suite:
```bash
pytest test_news_bots.py
```
Verify that all tests pass and outputs match expected results.
![image](https://github.com/user-attachments/assets/1568e8c8-88ff-468f-816c-0e4b7097e3e5)
