### PR TITLE
Test/user endpoint

### DIFF
--- a/test_data/delete_news_bot.json
+++ b/test_data/delete_news_bot.json
@@ -1,0 +1,13 @@
+{
+    "Test [xxx]: DELETE News Bot Schema Validation" : {
+        "payload": {
+            "name": "coinTest",
+            "alias": "CT",
+            "symbol": "ct",
+            "category_id": 1,
+            "run_frequency": 20
+        },
+        "status_code": 200,
+        "expected_response": "{\"error\": None, \"success\": True}"
+    }
+}

--- a/test_data/delete_user.json
+++ b/test_data/delete_user.json
@@ -1,0 +1,16 @@
+{
+    "Test [xxx]: DELETE User Schema Validation" : {
+        "payload": { 
+            "auth0id": "apple|001945.25da9f640de8487a8cf6ae750c9598f6.1323", 
+            "birth_date": "01/08/2020", 
+            "email": "felicitasperedo97+2@gmail.com", 
+            "email_verified": false, 
+            "full_name": "felicitas", 
+            "nickname": "felip2", 
+            "picture": null, 
+            "provider": null
+        },
+        "status_code": 200,
+        "expected_response": "{\"message\": \"User account and associated data deleted successfully\", \"success\": True}"
+    }
+}

--- a/test_data/post_news_bot.json
+++ b/test_data/post_news_bot.json
@@ -1,0 +1,52 @@
+{
+    "Test [xxx]: POST News Bots Schema Validation" : {
+        "payload": { 
+            "alias": "tc", 
+            "background_color": "#4287f5", 
+            "blacklist": "spam, scam, adult content", 
+            "category_id": 1, 
+            "dalle_prompt": "Dalle Pompt to test", 
+            "name": "testcoin", 
+            "run_frequency": 20, 
+            "url": "https://rss.news.google.com/search?q=tech%20news", 
+            "whitelist": "AI, machine learning, robotics"
+        },
+        "status_code": 201
+    },
+    "Test [xxx]: POST News Bots Required Fields Missing" : {
+        "payload": {},
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: name\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Name" : {
+        "payload": {
+            "alias": "CT"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: name\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Alias" : {
+        "payload": {
+            "name": "catTest"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: alias\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Category ID" : {
+        "payload": {
+            "name": "catTest",
+            "alias": "CT"
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: category_id\"}"
+    },
+    "Test [xxx]: POST News Bots Required Field Missing: Run Frequency" : {
+        "payload": {
+            "name": "catTest",
+            "alias": "CT",
+            "category_id": 1
+        },
+        "status_code": 400,
+        "expected_response": "{\"error\": \"Missing field in request data: run_frequency\"}"
+    }
+}

--- a/test_data/post_user.json
+++ b/test_data/post_user.json
@@ -1,0 +1,78 @@
+{
+    "Test [xxx]: POST User Schema Validation" : {
+        "payload": { 
+            "auth0id": "apple|001945.25da9f640de8487a8cf6ae750c9598f6.1323", 
+            "birth_date": "01/08/2020", 
+            "email": "testpost@gmail.com", 
+            "email_verified": false, 
+            "full_name": "felicitas", 
+            "nickname": "testpost", 
+            "picture": null, 
+            "provider": null
+        },
+        "status_code": 201
+    },
+    "Test [xxx]: POST User Required Fields Missing" : {
+        "payload": {},
+        "status_code": 400,
+        "expected_response": {
+            "message": {
+                "email": [
+                    "Missing data for required field."
+                ],
+                "nickname": [
+                    "Missing data for required field."
+                ],
+                "full_name": [
+                    "Missing data for required field."
+                ]
+            },
+            "success": false
+        }
+    },
+    "Test [xxx]: POST User Required Field Missing: Nickname" : {
+        "payload": {
+            "email": "felicitasperedo97+3@gmail.com",
+            "full_name": "felicitas"
+        },
+        "status_code": 400,
+        "expected_response": {
+            "message": {
+                "nickname": [
+                    "Missing data for required field."
+                ]
+            },
+            "success": false
+        }
+    },
+    "Test [xxx]: POST User Required Field Missing: Email" : {
+        "payload": {
+            "nickname": "felipe",
+            "full_name": "felicitas"
+        },
+        "status_code": 400,
+        "expected_response": {
+            "message": {
+                "email": [
+                    "Missing data for required field."
+                ]
+            },
+            "success": false
+        }
+    },
+    "Test [xxx]: POST User Required Field Missing: Full Name" : {
+        "payload": {
+            "nickname": "felipe",
+            "email": "felicitasperedo97+3@gmail.com"
+        },
+        "status_code": 400,
+        "expected_response": {
+            "message": {
+                "full_name": [
+                    "Missing data for required field."
+                ]
+            },
+            "success": false
+        }
+    }
+}

--- a/test_data/put_news_bot.json
+++ b/test_data/put_news_bot.json
@@ -1,0 +1,14 @@
+{
+    "Test [xxx]: PUT News Bot Schema Validation" : {
+        "payload": {
+            "name": "coinTest1",
+            "alias": "CT1",
+            "category_id": 2,
+            "background_color": "#4287f5",
+            "dalle_prompt": "Update Dalle Prompt to test", 
+            "run_frequency": 25,
+            "prompt":  "Update Prompt to test"
+        },
+        "status_code": 200
+    }
+}

--- a/test_data/put_user.json
+++ b/test_data/put_user.json
@@ -1,0 +1,10 @@
+{
+    "Test [xxx]: PUT User Schema Validation" : {
+        "payload": { 
+            "birth_date": "01/08/2001",  
+            "full_name": "felicitas pe", 
+            "nickname": "felip1234"
+        },
+        "status_code": 200
+    }
+}

--- a/test_data/schemas.py
+++ b/test_data/schemas.py
@@ -582,3 +582,70 @@ NEWS_BOT_RESPONSE_SCHEMA = {
   },
   "required": ["data", "error", "success"]
 }
+
+USER = {
+  "type": "object",
+  "properties": {
+    "auth0id": { "type": ["string", "null"]},
+    "auth_token": { "type": "string" },
+    "birth_date": { "type": ["string", "null"] },
+    "created_at": { "type": "string", "format": "date-time" },
+    "email": { "type": "string", "format": "email" },
+    "email_verified": { "type": ["string", "boolean"]},
+    "full_name": { "type": "string" },
+    "nickname": { "type": "string" },
+    "picture": { "type": ["string", "null"] },
+    "provider": { "type": ["string", "null"] },
+    "purchased_plans": {
+      "type": "array",
+      "items": { "type": "object" }
+    },
+    "updated_at": { "type": "string", "format": "date-time" },
+    "user_id": { "type": "integer" }
+  },
+  "required": [
+  "auth0id",
+  "auth_token",
+  "created_at",
+  "email",
+  "email_verified",
+  "full_name",
+  "nickname",
+  "updated_at",
+  "user_id"
+  ]
+}
+
+USERS_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": USER
+    },
+    "message": { "type": "string" },
+    "pagination": { "type": ["object", "null"] },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "message"]
+}
+
+USER_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "message": { "type": ["string", "object"] },
+    "success": { "type": "boolean" },
+    "user": USER
+  },
+  "required": ["message", "success"]
+}
+
+USER_RESPONSE_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": USER,
+    "message": { "type": "string" },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "message", "success"]
+}

--- a/test_data/schemas.py
+++ b/test_data/schemas.py
@@ -353,3 +353,232 @@ NEWS_BOTS_CATEGORY_SCHEMA = {
     },
     "required": ["error", "success"]
 }
+
+NEWS_BOTS_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "alias": { "type": ["null", "string"] },
+          "background_color": { "type": ["null", "string"] },
+          "category_id": { "type": "integer" },
+          "created_at": { "type": ["null", "string"], "format": "date-time" },
+          "dalle_prompt": { "type": ["null", "string"] },
+          "icon": { "type": ["null", "string"] },
+          "id": { "type": "integer" },
+          "is_active": { "type": "boolean" },
+          "name": { "type": "string" },
+          "prompt": { "type": ["null", "string"] },
+          "run_frequency": { "type": "string" },
+          "updated_at": { "type": ["null", "string"], "format": "date-time" }
+        },
+        "required": [
+          "alias",
+          "background_color",
+          "category_id",
+          "created_at",
+          "dalle_prompt",
+          "icon",
+          "id",
+          "is_active",
+          "name",
+          "prompt",
+          "run_frequency",
+          "updated_at"
+        ]
+      }
+    },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "success"]
+}
+
+POST_NEWS_BOT_RESPONSE = {
+  "type": "object",
+  "properties": {
+    "bot": {
+      "type": "object",
+      "properties": {
+        "alias": { "type": "string" },
+        "background_color": { "type": "string", "format": "color" },
+        "category_id": { "type": "integer" },
+        "created_at": { "type": "string", "format": "date-time" },
+        "dalle_prompt": { "type": "string" },
+        "icon": { "type": "string", "format": "uri" },
+        "id": { "type": "integer" },
+        "is_active": { "type": "boolean" },
+        "last_run_status": { "type": ["string", "null"] },
+        "last_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "name": { "type": "string" },
+        "next_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "prompt": { "type": "string" },
+        "run_count": { "type": "integer" },
+        "run_frequency": { "type": "integer" },
+        "status": { "type": "string" },
+        "updated_at": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "alias",
+        "background_color",
+        "category_id",
+        "created_at",
+        "dalle_prompt",
+        "icon",
+        "id",
+        "is_active",
+        "name",
+        "run_count",
+        "run_frequency",
+        "status",
+        "updated_at"
+      ]
+    },
+    "data": { "type": ["object", "null"] },
+    "error": { "type": ["object", "null", "string"] },
+    "message": { "type": "string" },
+    "success": { "type": "boolean" }
+  }
+}
+
+NEWS_BOT_METRICS_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "metrics": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "articles_processed": { "type": "integer" },
+              "articles_saved": { "type": "integer" },
+              "bot_id": { "type": "integer" },
+              "cpu_percent": { "type": "number" },
+              "end_time": { "type": ["string", "null"], "format": "date-time" },
+              "error_reasons": { "type": ["string", "null"] },
+              "filter_reasons": { "type": ["string", "null"] },
+              "id": { "type": "integer" },
+              "memory_percent": { "type": "number" },
+              "start_time": { "type": ["string", "null"], "format": "date-time" },
+              "total_articles_found": { "type": "integer" },
+              "total_errors": { "type": "integer" },
+              "total_filtered": { "type": "integer" },
+              "total_runtime": { "type": ["string", "null"] }
+            },
+            "required": [
+              "articles_processed",
+              "articles_saved",
+              "bot_id",
+              "cpu_percent",
+              "end_time",
+              "error_reasons",
+              "filter_reasons",
+              "id",
+              "memory_percent",
+              "start_time",
+              "total_articles_found",
+              "total_errors",
+              "total_filtered",
+              "total_runtime"
+            ]
+          }
+        },
+        "pagination": {
+          "type": "object",
+          "properties": {
+            "current_page": { "type": "integer" },
+            "has_next": { "type": "boolean" },
+            "has_prev": { "type": "boolean" },
+            "per_page": { "type": "integer" },
+            "total_items": { "type": "integer" },
+            "total_pages": { "type": "integer" }
+          },
+          "required": [
+            "current_page",
+            "has_next",
+            "has_prev",
+            "per_page",
+            "total_items",
+            "total_pages"
+          ]
+        }
+      },
+      "required": ["metrics", "pagination"]
+    },
+    "error": { "type": ["string", "null"] },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "error", "success"]
+}
+
+NEWS_BOT_RESPONSE_SCHEMA = {
+  "type": "object",
+  "properties": {
+    "data": {
+      "type": "object",
+      "properties": {
+        "alias": { "type": "string" },
+        "background_color": { "type": "string" },
+        "blacklist": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "category_id": { "type": "integer" },
+        "created_at": { "type": ["string", "null"], "format": "date-time" },
+        "dalle_prompt": { "type": "string" },
+        "icon": { "type": "string", "format": "uri" },
+        "id": { "type": "integer" },
+        "is_active": { "type": "boolean" },
+        "keywords": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "last_run_status": { "type": ["string", "null"] },
+        "last_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "name": { "type": "string" },
+        "next_run_time": { "type": ["string", "null"], "format": "date-time" },
+        "prompt": { "type": "string" },
+        "run_count": { "type": ["integer", "null"] },
+        "run_frequency": { "type": "string" },
+        "site": {
+          "type": "object",
+          "properties": {
+            "bot_id": { "type": "integer" },
+            "created_at": { "type": ["string", "null"], "format": "date-time" },
+            "id": { "type": "integer" },
+            "name": { "type": "string" },
+            "updated_at": { "type": ["string", "null"], "format": "date-time" },
+            "url": { "type": "string", "format": "uri" }
+          },
+          "required": ["bot_id", "id", "name", "url"]
+        },
+        "status": { "type": ["string", "null"] },
+        "updated_at": { "type": "string", "format": "date-time" }
+      },
+      "required": [
+        "alias",
+        "background_color",
+        "blacklist",
+        "category_id",
+        "dalle_prompt",
+        "icon",
+        "id",
+        "is_active",
+        "keywords",
+        "name",
+        "prompt",
+        "run_frequency",
+        "site",
+        "status",
+        "updated_at"
+      ]
+    },
+    "error": { "type": ["string", "null"] },
+    "success": { "type": "boolean" }
+  },
+  "required": ["data", "error", "success"]
+}

--- a/tests/test_news_bots.py
+++ b/tests/test_news_bots.py
@@ -1,0 +1,148 @@
+import pytest, os, json
+from dotenv import load_dotenv
+from utils.api_client import APIClient
+from utils.assertions import Assertions
+from utils.handlers import Handlers
+from test_data.schemas import NEWS_BOTS_SCHEMA, POST_NEWS_BOT_RESPONSE, NEWS_BOT_METRICS_SCHEMA, NEWS_BOT_RESPONSE_SCHEMA
+
+load_dotenv()
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_bots(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving all news bots data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bots")
+    Assertions.assert_status_code(response, 200)
+    Assertions.validate_schema(response.json(), NEWS_BOTS_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_news_bot.json")))
+def test_post_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the POST endpoint for creating a new news bot with associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code, expected response or JSON schema.
+    """
+    response = api_client.post("bot", json.dumps(test_data['payload']))
+    response_data = response.json()
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.validate_schema(response_data, POST_NEWS_BOT_RESPONSE)
+    if 'expected_response' in test_data:
+        Assertions.assert_response_contains(response_data, eval(test_data['expected_response']))
+    api_client.delete(f"bot/{response_data['bot']['id']}") if test_data['status_code'] == 201 else None
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_news_bot.json")))
+def test_delete_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the DELETE endpoint for deleting a news bot.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected response for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or response.
+    """
+    response = api_client.post("bot", json.dumps(test_data['payload']))
+    response_data = response.json()
+    response = api_client.delete(f"bot/{response_data['bot']['id']}")
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.assert_response_contains(response.json(), eval(test_data['expected_response']))
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_news_bot_metrics(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving metrics for a specific bot with pagination and date filtering options.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bot/33/metrics")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOT_METRICS_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_bot(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving information for a specific bot, including related keywords, blacklist items, and site data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("bot?bot_id=33")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, NEWS_BOT_RESPONSE_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"base_url": os.getenv("NEWS_BOT_URL"), "content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_news_bot.json")))
+def test_put_news_bot(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the PUT endpoint for updating an existing bot identified by its id. it allows for modification of various bot properties and associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.post("bot", json.dumps({'name': 'catTest','alias': 'CT', 'category_id': '1', 'run_frequency': 20}), [])
+    response_data = response.json()
+    response1 = api_client.put(f"bot/{response_data['bot']['id']}", json.dumps(test_data['payload'])) 
+    response_data1 = response1.json()
+    Assertions.assert_status_code(response1, test_data['status_code'])
+    test_data['payload']['icon'] = 'https://aialphaicons.s3.us-east-2.amazonaws.com/ct1.svg'
+    Assertions.assert_response_contains(response_data1['data'], test_data['payload'])
+    api_client.delete(f"bot/{response_data1['data']['id']}") if test_data['status_code'] == 200 else None
+
+    
+
+

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,0 +1,124 @@
+import pytest, os, json
+from dotenv import load_dotenv
+from utils.api_client import APIClient
+from utils.assertions import Assertions
+from utils.handlers import Handlers
+from test_data.schemas import USERS_SCHEMA, USER_SCHEMA, USER_RESPONSE_SCHEMA
+
+
+def test_get_users(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving all news bots data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("users")
+    Assertions.assert_status_code(response, 200)
+    Assertions.validate_schema(response.json(), USERS_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"accept": "application/json",
+      "content_type": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_user.json")))
+def test_post_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the POST endpoint for creating a new news bot with associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code, expected response or JSON schema.
+    """
+    response = api_client.post("user", json.dumps(test_data['payload']))
+    response_data = response.json()
+    print(response_data)
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.validate_schema(response_data, USER_SCHEMA)
+    if 'expected_response' in test_data:
+        Assertions.assert_response_contains(response_data, test_data['expected_response'])
+    api_client.delete(f"user", json.dumps({ "email": "testpost@gmail.com"})) if test_data['status_code'] == 201 else None
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_user.json")))
+def test_delete_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the DELETE endpoint for deleting a news bot.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected response for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code or response.
+    """
+    response = api_client.post("user", json.dumps({"email": "felicitasperedo@gmail.com", "full_name": "felicitas pe", "nickname": "testuser" }))
+    response_data = response.json()
+    response = api_client.delete("user", json.dumps({ "email": "felicitasperedo@gmail.com"}))
+    response_data = response.json()
+    Assertions.assert_status_code(response, test_data['status_code'])
+    Assertions.assert_response_contains(response.json(), eval(test_data['expected_response']))
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+def test_get_user(api_client: APIClient) -> None:
+    """
+    Tests the GET endpoint for retrieving information for a specific bot, including related keywords, blacklist items, and site data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+
+    Raises:
+        AssertionError: If the response does not meet the expected status code and JSON schema.
+    """
+    response = api_client.get("user?email=ferlymirza11@gmail.com")
+    Assertions.assert_status_code(response, 200)
+    response_data = response.json()
+    Assertions.validate_schema(response_data, USER_RESPONSE_SCHEMA)
+
+@pytest.mark.parametrize(
+    "api_client", 
+    [{"content_type": "application/json", "accept": "application/json"}], 
+    indirect=True
+)
+@pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_user.json")))
+def test_put_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
+    """
+    Tests the PUT endpoint for updating an existing bot identified by its id. it allows for modification of various bot properties and associated data.
+
+    Args:
+        api_client (APIClient): The API client used for making requests.
+        test_name (str): The name of the test case.
+        test_data (dict): The payload and expected status code for the request.
+
+    Raises:
+        AssertionError: If the response does not meet the expected conditions.
+    """
+    response = api_client.post("user", json.dumps({"email": "felicitasperedo97+6@gmail.com", "full_name": "felicitas pe", "nickname": "felip123456" }), [])
+    response_data = response.json()
+    response1 = api_client.put(f"user/{response_data['user']['user_id']}", json.dumps(test_data['payload'])) 
+    response_data1 = response1.json()
+    Assertions.assert_status_code(response1, test_data['status_code'])
+    Assertions.assert_response_contains(response_data1['data'], test_data['payload'])
+    api_client.delete(f"user", json.dumps({ "email": "felicitasperedo97+6@gmail.com"})) if test_data['status_code'] == 200 else None
+
+    
+
+

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -8,7 +8,7 @@ from test_data.schemas import USERS_SCHEMA, USER_SCHEMA, USER_RESPONSE_SCHEMA
 
 def test_get_users(api_client: APIClient) -> None:
     """
-    Tests the GET endpoint for retrieving all news bots data.
+    Tests the GET endpoint for retrieving all users with their purchased plans, with optional pagination.
 
     Args:
         api_client (APIClient): The API client used for making requests.
@@ -29,7 +29,7 @@ def test_get_users(api_client: APIClient) -> None:
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "post_user.json")))
 def test_post_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """
-    Tests the POST endpoint for creating a new news bot with associated data.
+    Tests the POST endpoint for registering a new user with associated data in the system.
 
     Args:
         api_client (APIClient): The API client used for making requests.
@@ -41,7 +41,6 @@ def test_post_user(api_client: APIClient, test_name: str, test_data: dict) -> No
     """
     response = api_client.post("user", json.dumps(test_data['payload']))
     response_data = response.json()
-    print(response_data)
     Assertions.assert_status_code(response, test_data['status_code'])
     Assertions.validate_schema(response_data, USER_SCHEMA)
     if 'expected_response' in test_data:
@@ -56,7 +55,7 @@ def test_post_user(api_client: APIClient, test_name: str, test_data: dict) -> No
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "delete_user.json")))
 def test_delete_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """
-    Tests the DELETE endpoint for deleting a news bot.
+    Tests the DELETE endpoint for deleting a user identified by auth0id or email.
 
     Args:
         api_client (APIClient): The API client used for making requests.
@@ -67,9 +66,7 @@ def test_delete_user(api_client: APIClient, test_name: str, test_data: dict) -> 
         AssertionError: If the response does not meet the expected status code or response.
     """
     response = api_client.post("user", json.dumps({"email": "felicitasperedo@gmail.com", "full_name": "felicitas pe", "nickname": "testuser" }))
-    response_data = response.json()
     response = api_client.delete("user", json.dumps({ "email": "felicitasperedo@gmail.com"}))
-    response_data = response.json()
     Assertions.assert_status_code(response, test_data['status_code'])
     Assertions.assert_response_contains(response.json(), eval(test_data['expected_response']))
 
@@ -80,7 +77,7 @@ def test_delete_user(api_client: APIClient, test_name: str, test_data: dict) -> 
 )
 def test_get_user(api_client: APIClient) -> None:
     """
-    Tests the GET endpoint for retrieving information for a specific bot, including related keywords, blacklist items, and site data.
+    Tests the GET endpoint for retrieving a specific user with their purchased plans.
 
     Args:
         api_client (APIClient): The API client used for making requests.
@@ -101,7 +98,7 @@ def test_get_user(api_client: APIClient) -> None:
 @pytest.mark.parametrize("test_name, test_data", Handlers.create_test_tuple(os.path.join(os.curdir, "test_data", "put_user.json")))
 def test_put_user(api_client: APIClient, test_name: str, test_data: dict) -> None:
     """
-    Tests the PUT endpoint for updating an existing bot identified by its id. it allows for modification of various bot properties and associated data.
+    Tests the PUT endpoint for updating an existing user identified by it's id. It allows for modification of various properties and associated data.
 
     Args:
         api_client (APIClient): The API client used for making requests.

--- a/utils/api_client.py
+++ b/utils/api_client.py
@@ -82,12 +82,13 @@ class APIClient:
         """
         return requests.put(f"{self.base_url}{endpoint}", data=data, headers=self.headers, files=files)
 
-    def delete(self, endpoint: str) -> Response:
+    def delete(self, endpoint: str, data: Optional[Dict[str, Any]] = None) -> Response:
         """
         Sends a DELETE request to the specified endpoint.
 
         Args:
             endpoint (str): The API endpoint (relative to the base URL).
+            data (dict[str, Any], optional): Data to send with the request (e.g., form data or JSON payload).
 
         Returns:
             Response: The response object from the DELETE request. Contains status code, content, etc.
@@ -95,5 +96,5 @@ class APIClient:
         Raises:
             requests.RequestException: If the DELETE request fails.
         """
-        return requests.delete(f"{self.base_url}{endpoint}", headers=self.headers)
+        return requests.delete(f"{self.base_url}{endpoint}", data=data, headers=self.headers)
 


### PR DESCRIPTION
This pull request introduces a comprehensive suite of automated tests for the user-related API endpoints. The tests cover various CRUD operations to ensure the reliability and accuracy of the API's functionality.

**Test Cases:**
test_get_users: Validates the GET /users endpoint, ensuring correct retrieval of all users and proper schema validation.
test_post_user: Validates the POST /user endpoint for user registration, including schema validation and response verification.
test_delete_user: Tests the DELETE /user endpoint, ensuring user records can be deleted as expected.
test_get_user: Validates the GET /user endpoint for fetching details of a specific user by email.
test_put_user: Tests the PUT /user endpoint to update user properties and validate the response schema and payload.

**Reusable Testing Utilities:**
Parameterized tests using pytest.mark.parametrize for dynamic test data input.
Test data management through external JSON files.
Use of Handlers.create_test_tuple to dynamically load test cases.

**Error Handling and Cleanup:**
Ensures proper error assertions when endpoints fail to meet expectations.
Includes cleanup operations (e.g., deleting test-created users) to maintain test environment integrity.

**Key Features**
Schema Validation: Ensures that all responses adhere to predefined schemas (USERS_SCHEMA, USER_SCHEMA, USER_RESPONSE_SCHEMA).
Dynamic Test Inputs: Incorporates diverse test cases loaded from JSON files for enhanced coverage.
Clean Test Environment: Each test cleans up after execution to avoid residual test data.

**Additional Notes**
The dotenv integration ensures environment variables can be loaded seamlessly during test execution.
This PR leverages modular and reusable components (Handlers, Assertions) for maintainable and scalable testing.

**Testing Instructions**
Ensure that all required dependencies (pytest, dotenv, etc.) are installed.
Run the test suite using:

```
pytest .\tests\test_user.py`
```

Confirm that all tests pass successfully.

**Evidence:**
![image](https://github.com/user-attachments/assets/6f00820e-acf7-4d4f-a5ab-32fe301265d3)

